### PR TITLE
Removing inconsistent "tip" from Tiled Sprite Page.

### DIFF
--- a/docs/gdevelop5/objects/tiled_sprite.md
+++ b/docs/gdevelop5/objects/tiled_sprite.md
@@ -3,12 +3,6 @@ title: Tiled Sprite
 ---
 # Tiled Sprite
 
-!!! tip
-
-        **See it in action!** 🎮
-    [I would rather see the Tiled Sprite object examples! Please take me there now.](/#Examples)
-
-
 A tiled sprite [object](/gdevelop5/objects) allows us to use repeating images in our games. increasing the width or height of the object will cause it repeat it's image, rather than stretching the image like a normal sprite object.
 
 A tiled sprite object can be used to create platforms in a platform game, health bars, status bars, repeating wall tiles, repeating backgrounds, etc.


### PR DESCRIPTION
The "Tip" section above this page had a broken link, and it being there was inconsistent with the style of all other object pages, so I removed it.