### PR TITLE
Base Layer explanation and adding user's intention

### DIFF
--- a/docs/gdevelop5/tutorials/follow-player-with-camera/index.md
+++ b/docs/gdevelop5/tutorials/follow-player-with-camera/index.md
@@ -14,7 +14,7 @@ This article includes instructions for implementing this functionality either wi
     GDevelop [assigns a single camera per layer](https://wiki.gdevelop.io/gdevelop5/interface/scene-editor/layers-and-cameras/#cameras). It is recomended to start by placing the main objects o the "Base Layer", and add other layers after. 
 
 
-## Follow a character smoothly
+## Follow an object (character) smoothly
 
 Add the **Smooth Camera** [behavior](https://wiki.gdevelop.io/gdevelop5/behaviors#adding_a_behavior_to_an_object) to the object that will be followed.
 The extension's parameters such as "catch up" and "speed" can be modified to personalize the smoothness of the camera.
@@ -38,11 +38,11 @@ The **Action** should look like this:
 
     To get closer to the character with the camera (zoom-in), use the action **Move camera closer**.
     
-### Follow several objects together
+### Follow an object with several cameras
 
-Games can contain a lot of objects. Using several layers is a way to keep a project organized, but also to manage camera movements. All layers (except for UI layers) should likely be moved the same way when a character is followed. *Read more on [how does cameras and layers](https://wiki.gdevelop.io/gdevelop5/interface/scene-editor/layers-and-cameras/#dimensions-and-angle-of-the-camera) work.*
+Games can contain a lot of objects. Using several layers is a way to keep a project organized, but also to manage camera movements. All layers (except for UI layers) should likely be moved the same way when a character is followed. *Read more on [how cameras and layers](https://wiki.gdevelop.io/gdevelop5/interface/scene-editor/layers-and-cameras/#dimensions-and-angle-of-the-camera) work.*
 
-To follow several objects at the same time, install the **[Copy camera settings](https://wiki.gdevelop.io/gdevelop5/extensions/copy-camera-settings/)** extension. It allows to copy the camera's position to another camera, including the camera that follows the player.
+To follow a single object with different layers (each layer has a single camera), install the **[Copy camera settings](https://wiki.gdevelop.io/gdevelop5/extensions/copy-camera-settings/)** extension. It allows to copy the main camera's position to a secondary camera.
 
 
 ## Make a custom camera following (advanced)

--- a/docs/gdevelop5/tutorials/follow-player-with-camera/index.md
+++ b/docs/gdevelop5/tutorials/follow-player-with-camera/index.md
@@ -11,17 +11,17 @@ This article includes instructions for implementing this functionality either wi
 
 !!! tip
 
-    Learn more about [layers and cameras](https://wiki.gdevelop.io/gdevelop5/interface/scene-editor/layers-and-cameras/#cameras) and [how to keep UI objects on screen](/gdevelop5/tutorials/keep-ui-on-screen).
+    GDevelop [assigns a single camera per layer](https://wiki.gdevelop.io/gdevelop5/interface/scene-editor/layers-and-cameras/#cameras). It is recomended to start by placing the main objects o the "Base Layer", and add other layers after. 
 
 
 ## Follow a character smoothly
 
-Add the **Smooth Camera** [behavior](https://wiki.gdevelop.io/gdevelop5/behaviors#adding_a_behavior_to_an_object) to the object *(remember to [install it first](https://wiki.gdevelop.io/gdevelop5/extensions/search/) from the Extension catalog)*. The **Smooth Camera's** parameters such as "catch up" and "speed" can be modified to personalize the smoothness of the camera.
+Add the **Smooth Camera** [behavior](https://wiki.gdevelop.io/gdevelop5/behaviors#adding_a_behavior_to_an_object) to the object that will be followed.
+The extension's parameters such as "catch up" and "speed" can be modified to personalize the smoothness of the camera.
 
 !!! tip
 
-    Make sure that the character, enemies and platforms on the project are placed on the "Base Layer" on the layer panel. If the issue persist, ask the community on the [forum](https://forum.gdevelop.io/t/camera-not-following-character/45356).
-
+    Learn [how to install](https://gdevelop-wiki-git-fork-lunimoon-patch-2-gdevelop.vercel.app/gdevelop5/extensions/search/) new extensions by following a step-by-step guide.
 
 
 ### Keep a character at the exact center of the camera
@@ -49,3 +49,6 @@ To follow several objects at the same time, install the **[Copy camera settings]
 
 To add camera inertia and a smoother transition watch [this video tutorial](https://youtu.be/yUNisggNh7s?t=84) to learn how to use the Camera Center positions on the X and Y axis, along with `lerp` expressions and formulas.
 
+
+## You might be interested in:
+- How to [keep UI objects on screen](/gdevelop5/tutorials/keep-ui-on-screen).

--- a/docs/gdevelop5/tutorials/follow-player-with-camera/index.md
+++ b/docs/gdevelop5/tutorials/follow-player-with-camera/index.md
@@ -14,33 +14,38 @@ This article includes instructions for implementing this functionality either wi
     Learn more about [layers and cameras](https://wiki.gdevelop.io/gdevelop5/interface/scene-editor/layers-and-cameras/#cameras) and [how to keep UI objects on screen](/gdevelop5/tutorials/keep-ui-on-screen).
 
 
-## Follow an object smoothly
+## Follow a character smoothly
 
-Adding the **Smooth Camera** [behavior](https://wiki.gdevelop.io/gdevelop5/behaviors#adding_a_behavior_to_an_object) to the character make the camera follow it automatically. The **Move camera closer** action can still be used to avoid a 1-frame delay.
+Add the **Smooth Camera** [behavior](https://wiki.gdevelop.io/gdevelop5/behaviors#adding_a_behavior_to_an_object) to the object *(remember to [install it first](https://wiki.gdevelop.io/gdevelop5/extensions/search/) from the Extension catalog)*. The **Smooth Camera's** parameters such as "catch up" and "speed" can be modified to personalize the smoothness of the camera.
 
 !!! tip
 
-    Learn [how to install new extensions](/gdevelop5/extensions/search) by following a step-by-step guide.
+    Make sure that the character, enemies and platforms on the project are placed on the "Base Layer" on the layer panel. If the issue persist, ask the community on the [forum](https://forum.gdevelop.io/t/camera-not-following-character/45356).
 
 
-## Move several layers together
 
-Games can contain a lot of objects and using several layers is a good solution to organize a project. All layers (except for UI layers) should likely be moved the same way when a character is followed.
+### Keep a character at the exact center of the camera
 
-The [copy camera settings](https://wiki.gdevelop.io/gdevelop5/extensions/copy-camera-settings/) extension allows to copy a camera position to another one. The camera that follows the player can be copied to any other camera layers.
+To configure the camera to center on an object, go to the [event sheet](https://wiki.gdevelop.io/gdevelop5/events) and **add an Action** *(no need to set a Condition)* called **"Center the camera on an object"**.
 
-
-## Keep an object at the exact center of the screen
-
-To configure the camera to follow an object, go to the [event sheet](https://wiki.gdevelop.io/gdevelop5/events) and **add an Action** *(no need to set a Condition)* called **"Center the camera on an object"**.
-
-After that, select the character that will be followed by the camera and check that the layer of the character is selected.
+Select the object that will be followed by the camera and make sure that the layer where the object is placed is selected.
 
 The **Action** should look like this:
 
 ![](pasted/20230316-155732.png)
 
+!!! tip
 
-## Make a custom camera following
+    To get closer to the character with the camera (zoom-in), use the action **Move camera closer**.
+    
+### Follow several objects together
+
+Games can contain a lot of objects. Using several layers is a way to keep a project organized, but also to manage camera movements. All layers (except for UI layers) should likely be moved the same way when a character is followed. *Read more on [how does cameras and layers](https://wiki.gdevelop.io/gdevelop5/interface/scene-editor/layers-and-cameras/#dimensions-and-angle-of-the-camera) work.*
+
+To follow several objects at the same time, install the **[Copy camera settings](https://wiki.gdevelop.io/gdevelop5/extensions/copy-camera-settings/)** extension. It allows to copy the camera's position to another camera, including the camera that follows the player.
+
+
+## Make a custom camera following (advanced)
 
 To add camera inertia and a smoother transition watch [this video tutorial](https://youtu.be/yUNisggNh7s?t=84) to learn how to use the Camera Center positions on the X and Y axis, along with `lerp` expressions and formulas.
+


### PR DESCRIPTION
I noticed that the small (but important) notion of "keeping objects on the base layer" disappeared. So, I added it back.

I also changed some words to match user's search and reading intention: *following* an object vs *moving* an object, *camera* vs *layer* (I changed the word "layers" for "objects" because even if it's technically correct, the intention of the reader is on an object, not on a layer). 

I "deprioritised" the use of other extensions like "copy camera settings", but I still included it under the "follow smoothly" section.