### PR TITLE
Fix the Fire Bullet diagram page title.

### DIFF
--- a/docs/gdevelop5/extensions/fire-bullet/diagrams.md
+++ b/docs/gdevelop5/extensions/fire-bullet/diagrams.md
@@ -1,7 +1,10 @@
 ---
 title: Diagrams
 ---
-# Fire Bullet
+# Fire Bullet technical documentation
+
+!!! tip
+    Learn how to use the [Fire Bullet](/gdevelop5/extensions/fire-bullet/details) extension.
 
 ## Logic diagram
 


### PR DESCRIPTION
https://gdevelop-wiki-git-fire-bullet-diagram-title-gdevelop.vercel.app/gdevelop5/extensions/fire-bullet/diagrams/