### PR TITLE
[Move objects] Add a section about tweens

### DIFF
--- a/docs/gdevelop5/tutorials/how-to-move-objects/index.md
+++ b/docs/gdevelop5/tutorials/how-to-move-objects/index.md
@@ -17,13 +17,17 @@ There are three different ways of changing an object position in GDevelop:
 * By adding a force on an object (this work on all objects),
 * By using a behavior (which internally will either change the coordinates or use forces!).
 
-## No movement: change an object position
+## Change an object position
 
 Sometimes you want to instantly change an object's position, instead of gradually moving or animating it. In this case, use the action to set the object at a specific position (by specifying new X and Y coordinates):
 
 ![](set-object-position.png)
 
-## Follow another object exactly: changing the position with expressions
+## Move an object between 2 positions
+
+The [tween behavior](/gdevelop5/behaviors/tween) can be used to move an object to a new position over time with various speed patterns.
+
+## Move several objects together
 
 If you want an object to follow another object exactly, or be fixed to another object's position, use the action to change an object position and use the expressions to get the X and Y coordinates of the object to follow.
 
@@ -35,25 +39,9 @@ Here is an example to set the position of the Player object in a platform game:
 
 !!! tip
 
-
     The [sticker extension](/gdevelop5/extensions/sticker/reference) allows to follow the position,  angle and dimension of another object.
 
-
-## Make a cursor: change the position and use "MouseX()";"MouseY()"
-
-Want an object to act as a cursor? Change its position to set it to `MouseX()` on X axis and `MouseY()` on Y axis.
-
-![](cursor-set-position.png)
-
-!!! note
-
-    It's a good idea to put the "cursor" object on top of all other by using a high Z order or move it to another layer. In this case, enter the layer name as argument to `MouseX` and `MouseY`. For example, if the layer is called "user interface": `MouseX("user interface")`, `MouseY("user interface")`
-
-!!! tip
-
-    Learn more about how to handle mouse on the [mouse and touch events](/gdevelop5/all-features/mouse-touch) page.
-
-## Move an object on screen: use forces
+## Move an object in a direction using forces
 
 The easiest way to move an object, continuously or when something happens like the player pressing a button, is to use **forces**.
 
@@ -77,7 +65,7 @@ Permanent forces are akin to launching a music: you only want to start a music o
 
      Technically, the force is moving the object by the length of the force multiplied by the time elapsed to render the frame. This means that forces speed is in pixel per seconds. Note that you don't need to understand this to use forces, but make sure to use the right kind of force (instant or permanent) to avoid bad results in your game.
 
-## Platformer behavior
+## Move a platformer character
 
 If your object is a character in a platformer game, the [platformer behavior](/gdevelop5/behaviors/platformer) will allow to use a ready-made platformer engine in your game.
 
@@ -86,7 +74,7 @@ If your object is a character in a platformer game, the [platformer behavior](/g
 
 You can edit the properties of the behaviors and use events to customize the way platformer characters work.
 
-## Physics engine
+## Collide objects realistically
 
 If your objects must follow the law of physics, for example to simulate boxes falling and bouncing on the floor, consider using the [Physics engine behavior](/gdevelop5/behaviors/physics2).
 
@@ -96,13 +84,13 @@ The Physics engine is *more complex* than forces and behaviors like the Platform
 
     Objects that have the Physics behavior are moved by the Physics engine. If you try to move them with forces or other actions not part of the Physics behavior, the Physics engine will struggle to keep the simulation realistic - and some "glitches" can then be seen.
 
-## Ellipse movement behavior
+## Move an object in circle
 
 The [ellipse movement](/gdevelop5/extensions/ellipse-movement/reference) behavior is a behavior that you can [install in your game from extensions](/gdevelop5/extensions/search).
 
 After adding it to an object, you can set up the amplitude of the movement on the X and Y axis. This is useful to make objects always move in circle or following an ellipse.
 
-## Forces and bounce behavior
+## Make an object bounce
 
 The [bounce behavior](/gdevelop5/behaviors/bounce) is a behavior that you can [install in your game from extensions](/gdevelop5/extensions/search).
 
@@ -112,13 +100,13 @@ After adding it to an object, add a condition to check if the object is in colli
 
     This behavior is working with forces! Make your object move by adding a force to it. Then add the behavior and the action to make it bounce in case of collisions
 
-## Pathfinding: Find a path around obstacles and follow it
+## Find a path around obstacles
 
 The [Pathfinding behavior](/gdevelop5/behaviors/pathfinding) is an advanced algorithm that compute a path between an object position and a destination position. The path will be the shortest one avoiding other objects marked as obstacles.
 
 It's useful for strategy games and any game where characters or units must move on their own and avoid obstacles.
 
-## Anchor behavior: ensure that your object is pinned on the screen even if window is resized
+## Pin an object on screen edges when the window is resized
 
 With the [Anchor behavior](/gdevelop5/behaviors/anchor), you can set your object to be pinned to the top, left, bottom or right of the game. If the game window is resized, and the game resolution is changed, the object will be automatically re-adjusted to be at the same distance from the window border as before.
 


### PR DESCRIPTION
https://gdevelop-wiki-git-move-with-tween-gdevelop.vercel.app/gdevelop5/tutorials/how-to-move-objects/

### Changes
- Add a section about tweens
- Remove the section "Make a cursor"
  - It use deprecated expressions
  - It's out of subject, it's not really a movement
  - there is an extension that do just this
- Simplify titles wording