### PR TITLE
Add shadow info for 3D objects

### DIFF
--- a/docs/gdevelop5/objects/3d-box/index.md
+++ b/docs/gdevelop5/objects/3d-box/index.md
@@ -24,6 +24,16 @@ Lighting can be set up through [layers effects](../../interface/scene-editor/lay
 - Either it does not react to light, meaning that it's always shown with the colors of the texture that was set (like a 2D object)
 - Or it does react to light. In this case, don't forget to set up a light in the layer effects.
 
+## Shadows
+
+3D boxes can cast and receive shadows. To see them:
+
+- Add a **Directional Light** effect to the layer (new layers already include one and an Ambient Light).
+- Ensure the box uses the **Standard** material.
+- Enable **Shadow casting** and **Shadow receiving** in the object's properties (these are enabled for new objects by default).
+
+Shadows are rendered around the camera. You can tweak their range, quality and the light intensity by editing the Directional Light effect in the layer.
+
 ## About transparency
 
 Support for transparency (faces with transparent or semi opaque colors) can be enabled by checking the checkbox **"Enable texture transparency"** when editing a 3D box object.

--- a/docs/gdevelop5/objects/3d-model/index.md
+++ b/docs/gdevelop5/objects/3d-model/index.md
@@ -13,6 +13,16 @@ Lighting can be set up through [layers effects](../../interface/scene-editor/lay
 
 The model can be set up to react to lighting in different ways. The GLTF format can include data about light reflection. The 3D model can either use this data or use a forced configuration.
 
+## Shadows
+
+3D models can cast and receive shadows. To display shadows:
+
+- Ensure the layer has a **Directional Light** effect. New layers in new games include this effect along with an Ambient Light by default.
+- Set the object's material to **Standard** (not **Basic**, which ignores lighting).
+- Enable **Shadow casting** and **Shadow receiving** in the object's properties (enabled by default for new assets from the store).
+
+Shadows are computed around the camera with a range suitable for most games. You can adjust the light intensity, shadow quality and range by editing the Directional Light effect in the layer's effects.
+
 ## File format
 
 GDevelop supports 3D models saved in the **GLB (.glb) format**. It is a standardized file format used to share 3D data. Notably, it includes the 3D mesh of the object, as well as its textures or material specifications. This format is also sometimes called **GLTF**, for "GL Transmission Format". You can sometimes find .gltf files, but only the **.glb** files are supported by GDevelop, as they can embed the textures whereas .gltf files can't do this.


### PR DESCRIPTION
## Summary
- document that 3D boxes and 3D models can cast and receive shadows
- describe requirements for Directional Light and Standard material

## Testing
- `mkdocs build --strict` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68653c92efd0832784a50e8dd35b7a93