### PR TITLE
Add documentation for scene resource loading options

### DIFF
--- a/docs/gdevelop5/all-features/resources-loading/index.md
+++ b/docs/gdevelop5/all-features/resources-loading/index.md
@@ -15,6 +15,17 @@ The resources used by other scenes are downloaded in background while users inte
 
 It may happen that all the resources needed for a scene are not ready when the scene must be displayed. In this case, the loading is shown a second time while its resources are downloaded as soon as possible.
 
+## Control preloading and unloading
+
+By default, the resources of every scene are preloaded in the background and kept in memory even after leaving a scene. This makes switching scenes faster but increases memory usage.
+
+You can change this behavior:
+
+* In **Project properties**, modify **Scenes resources preloading** to disable preloading for all scenes.
+* In **Scene properties**, override the preloading for a particular scene and use **Resources unloading** to remove its resources from memory when leaving it.
+
+When a scene with unloading enabled is displayed again, its resources are loaded once more. These options are helpful for large or modular games or to reduce memory usage in web games.
+
 ## Optimize resource loading
 
 Intermediary loading screens can be avoided by choosing in which order scenes are pre-loaded.

--- a/docs/gdevelop5/interface/project-manager/properties.md
+++ b/docs/gdevelop5/interface/project-manager/properties.md
@@ -25,6 +25,8 @@ It is in these properties, you can find:
 * **Project file type:** By default, your game is saved in a single file. You can also choose to save it as multiple files: each scene, external layout, and external event sheet will be saved in a different file. This is perfect for working on a large game in a team and sharing your game in a version control system like Github or Mercurial.
 * **AdMob application ID (for iOS and Android):** ID number used to connect your game with your AdMob account. Only required if you're running ads in your game. [Read more about AdMob](/gdevelop5/all-features/admob).
 * **Firebase configuration string:** The mandatory authentication key for use with Firebase events. Only required if you're using Firebase in your project. [Read more about Firebase](https://wiki.gdevelop.io/gdevelop5/all-features/firebase/quickstart).
+* **Scenes resources preloading:** Choose if all scenes should preload their resources in background (default), or disable preloading. This setting can be overridden for each scene from the Scene properties.
+* **Resources unloading:** Decide whether the resources of a scene are unloaded when the scene is left. If enabled, they will be loaded again the next time the scene starts.
 
 
 ## Branding and Loading screen


### PR DESCRIPTION
## Summary
- document new 'Scenes resources preloading' and 'Resources unloading' options in project properties
- explain how to control scene resource preloading/unloading

## Testing
- `mkdocs --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68653dd387ac8327a862cc9233902083