### PR TITLE
Update collaboration to avoid Edu confusion

### DIFF
--- a/docs/gdevelop5/collaboration/index.md
+++ b/docs/gdevelop5/collaboration/index.md
@@ -16,7 +16,7 @@ There are two requirements to collaborate on a project:
 
 !!! note 
 
-    Are you working in education and **would like students to collaborate** on a project? The Pro subscription is **most probably not adapted to your use-case**. Check out the [GDevelop for Education plan](https://gdevelop.io/pricing/education) instead.
+    Are you in the field of education? This feature is **NOT ready for production and it is **NOT** part of the GDevelop for Education subscription. Check out the [GDevelop for Education plan](https://gdevelop.io/pricing/education) for all of the features bundled there instead, including a full curriculum, classroom management tools, remote student project overview, and more.
 
 ## Invite people to share a project
 


### PR DESCRIPTION
Changed wording to prevent teachers thinking that real-time collab is part of the GDev4Edu subscription.