### PR TITLE
Add navigation icons to key documentation sections

### DIFF
--- a/docs/gdevelop5/all-features/index.md
+++ b/docs/gdevelop5/all-features/index.md
@@ -1,3 +1,7 @@
+---
+title: All features
+icon: material/view-grid-outline
+---
 # All features
 
 This page lists **all the features** that are provided in GDevelop. These can be objects, behaviors but also features that can be used directly using actions, conditions or expressions (without requiring an object to be existing on the scene).

--- a/docs/gdevelop5/behaviors/index.md
+++ b/docs/gdevelop5/behaviors/index.md
@@ -1,5 +1,6 @@
 ---
 title: Behaviors
+icon: material/tune
 ---
 # Behaviors
 

--- a/docs/gdevelop5/events/index.md
+++ b/docs/gdevelop5/events/index.md
@@ -1,5 +1,6 @@
 ---
 title: Events
+icon: material/flash
 ---
 # Events
 

--- a/docs/gdevelop5/getting_started/index.md
+++ b/docs/gdevelop5/getting_started/index.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Started with GDevelop
+icon: material/rocket-launch
 ---
 # Getting Started with GDevelop
 

--- a/docs/gdevelop5/interface/index.md
+++ b/docs/gdevelop5/interface/index.md
@@ -1,5 +1,6 @@
 ---
 title: GDevelop interface
+icon: material/monitor
 ---
 # GDevelop's user interface
 

--- a/docs/gdevelop5/objects/index.md
+++ b/docs/gdevelop5/objects/index.md
@@ -1,5 +1,6 @@
 ---
 title: Objects
+icon: material/cube-outline
 ---
 # Objects
 


### PR DESCRIPTION
## Summary
- add Material for MkDocs icon metadata to the Getting Started, Interface, Objects, Behaviors, Events, and All features sections
- add front matter to the All features index page so the icon metadata can be recognized

## Testing
- mkdocs build (warnings about existing missing links and redirects)

------
https://chatgpt.com/codex/tasks/task_b_68ea324ed12083279b6176ed717884c5