### PR TITLE
Add icons to left menu

### DIFF
--- a/docs/gdevelop5/.pages
+++ b/docs/gdevelop5/.pages
@@ -1,12 +1,12 @@
 title: GDevelop 5
 nav:
   - index.md
-  - getting_started
-  - interface
-  - objects
-  - behaviors
-  - events
-  - all-features
+  - ":material-rocket-launch: Getting started": getting_started
+  - ":material-view-dashboard-outline: Interface": interface
+  - ":material-cube-outline: Objects": objects
+  - ":material-cog-outline: Behaviors": behaviors
+  - ":material-flash-outline: Events": events
+  - ":material-view-grid-outline: All features": all-features
   - extensions
   - Tutorials and Guides: tutorials
   - Publishing games: publishing

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,10 @@ markdown_extensions:
   - admonition
   - pymdownx.details
   - pymdownx.superfences
+  # For icons and emojis in content and navigation:
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   # For tables:
   - tables
   # For lists not starting with a blank line:


### PR DESCRIPTION
Add Material for MkDocs icons to the left menu navigation and enable the emoji extension for rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-114f9dab-922e-4f15-be96-678570c28edd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-114f9dab-922e-4f15-be96-678570c28edd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

