### PR TITLE
Add sidebar icons to major GDevelop 5 sections

### DIFF
--- a/docs/gdevelop5/all-features/index.md
+++ b/docs/gdevelop5/all-features/index.md
@@ -1,3 +1,8 @@
+---
+title: All features
+icon: material/view-grid-outline
+---
+
 # All features
 
 This page lists **all the features** that are provided in GDevelop. These can be objects, behaviors but also features that can be used directly using actions, conditions or expressions (without requiring an object to be existing on the scene).

--- a/docs/gdevelop5/behaviors/index.md
+++ b/docs/gdevelop5/behaviors/index.md
@@ -1,5 +1,6 @@
 ---
 title: Behaviors
+icon: material/robot-outline
 ---
 # Behaviors
 

--- a/docs/gdevelop5/collaboration/index.md
+++ b/docs/gdevelop5/collaboration/index.md
@@ -1,5 +1,6 @@
 ---
 title: Collaborate on a GDevelop project
+icon: material/account-multiple-check
 ---
 
 # Collaborate on a GDevelop project

--- a/docs/gdevelop5/community/index.md
+++ b/docs/gdevelop5/community/index.md
@@ -1,5 +1,6 @@
 ---
 title: GDevelop community
+icon: material/account-group
 ---
 # GDevelop community
 

--- a/docs/gdevelop5/education/index.md
+++ b/docs/gdevelop5/education/index.md
@@ -1,5 +1,6 @@
 ---
 title: GDevelop for Education
+icon: material/school
 ---
 
 # GDevelop for Education

--- a/docs/gdevelop5/events/index.md
+++ b/docs/gdevelop5/events/index.md
@@ -1,5 +1,6 @@
 ---
 title: Events
+icon: material/flash
 ---
 # Events
 

--- a/docs/gdevelop5/extensions/index.md
+++ b/docs/gdevelop5/extensions/index.md
@@ -1,3 +1,8 @@
+---
+title: Extensions
+icon: material/puzzle-outline
+---
+
 # Extensions
 
 GDevelop is built in a flexible way. In addition to [core features](/gdevelop5/all-features), new capabilities are provided by extensions. Extensions can contain objects, behaviors, actions, conditions, expressions or events.

--- a/docs/gdevelop5/getting_started/index.md
+++ b/docs/gdevelop5/getting_started/index.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Started with GDevelop
+icon: material/rocket-launch
 ---
 # Getting Started with GDevelop
 

--- a/docs/gdevelop5/interface/index.md
+++ b/docs/gdevelop5/interface/index.md
@@ -1,5 +1,6 @@
 ---
 title: GDevelop interface
+icon: material/monitor-dashboard
 ---
 # GDevelop's user interface
 

--- a/docs/gdevelop5/monetization/index.md
+++ b/docs/gdevelop5/monetization/index.md
@@ -1,5 +1,6 @@
 ---
 title: Monetizing Your Games
+icon: material/cash-multiple
 ---
 
 # Monetizing Your Games

--- a/docs/gdevelop5/objects/index.md
+++ b/docs/gdevelop5/objects/index.md
@@ -1,5 +1,6 @@
 ---
 title: Objects
+icon: material/cube-outline
 ---
 # Objects
 

--- a/docs/gdevelop5/publishing/index.md
+++ b/docs/gdevelop5/publishing/index.md
@@ -1,5 +1,6 @@
 ---
 title: Publishing games
+icon: material/cloud-upload
 ---
 # Publishing games
 

--- a/docs/gdevelop5/tutorials/index.md
+++ b/docs/gdevelop5/tutorials/index.md
@@ -1,5 +1,6 @@
 ---
 title: GDevelop 5 tutorials
+icon: material/book-open-variant
 ---
 
 # GDevelop 5 tutorials


### PR DESCRIPTION
## Summary
- add Material for MkDocs icon metadata to the key GDevelop 5 section index pages so the navigation shows representative icons
- introduce front matter for sections that lacked it to support the new icon settings

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_b_68ea3a643ed88327b386f0d3163682ef