### PR TITLE
Custom object variant documentation

### DIFF
--- a/docs/gdevelop5/objects/custom-objects-prefab-template/index.md
+++ b/docs/gdevelop5/objects/custom-objects-prefab-template/index.md
@@ -62,7 +62,7 @@ The grey rectangle on the scene is the custom object default size. Your can chan
 
 ![](./object-scene-properties.png)
 
-## Custom object variants
+## Custom object variants: create various styles or configurations
 
 **Variants** allow you to create different visual styles or configurations of the same custom object. Each variant can have its own child object configurations (like different images, fonts, or colors) and initial instance placements, while sharing the same events and logic.
 
@@ -84,13 +84,9 @@ To create a new variant:
 
 When you use the custom object in a scene, you can select which variant to use from the object properties.
 
-!!! tip
+### Making variants using different objects inside
 
-    For more details on migrating existing custom objects to use variants, see [Migrate custom objects to variants](/gdevelop5/objects/custom-objects-prefab-template/migrate-to-variants).
-
-### Child objects are shared across all variants
-
-An important thing to understand is that **all variants of a custom object share the same set of child objects**. This is because all variants use the same events, and the events reference child objects by name. If a child object exists in one variant, it must exist in all variants.
+An important thing to understand is that **all variants of a custom object share the same set of child objects**. This is because all variants use the same events: if a child object exists in one variant, it must exist in all variants.
 
 In practice, this means:
 


### PR DESCRIPTION
Add documentation for custom object variants and clarify that child objects are shared across all variants.

This PR addresses a user's confusion about not being able to add/remove child objects in specific variants, explaining that all variants share the same set of child objects due to shared events. This clarifies the intended behavior and provides guidance on how to manage optional child objects.

---
<a href="https://cursor.com/background-agent?bcId=bc-eef024b7-2102-4a78-b1a2-28dd857d0af9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eef024b7-2102-4a78-b1a2-28dd857d0af9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

