### PR TITLE
Forward the old navmesh reference page to the new doc

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,7 @@ plugins:
         "gdevelop5/interface/ai/agent/index.md": "gdevelop5/interface/ai/index.md"
         "gdevelop5/interface/ai/chat/index.md": "gdevelop5/interface/ai/index.md"
         "gdevelop5/interface/scene-editor/events.md": "gdevelop5/interface/events-editor/index.md"
+        "gdevelop5/extensions/nav-mesh-pathfinding/index.md": "gdevelop5/behaviors/nav-mesh-pathfinding/index.md"
         # Tutorials
         "gdevelop5/tutorials/platformer/start.md": "gdevelop5/tutorials/platformer/index.md"
         "gdevelop5/tutorials/asteroids/start.md": "gdevelop5/tutorials/asteroids/index.md"


### PR DESCRIPTION
- https://gdevelop-wiki-git-forward-nav-mesh-gdevelop.vercel.app/gdevelop5/extensions/nav-mesh-pathfinding/